### PR TITLE
feat: Add leader field to User model and Team model

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -48,6 +48,7 @@ model User {
   email         String?   @unique
   role          UserRole  @default(PARTICIPANT)
   events        Event[]
+  leader        Team?
   emailVerified DateTime? @map("email_verified")
   image         String?
   accounts      Account[]
@@ -56,7 +57,16 @@ model User {
   @@map("users")
 }
 
+model Team {
+  id       String @id @default(cuid())
+  name     String
+  eventId  String @map("event_id")
+  event    Event  @relation(fields: [eventId], references: [id])
+  leaderId String @unique
+  leader   User   @relation(fields: [leaderId], references: [id])
 
+  @@map("teams")
+}
 
 model Event {
   id               String   @id @default(cuid())
@@ -67,6 +77,7 @@ model Event {
   coordinator      User?    @relation(fields: [coordinatorEmail], references: [email])
   coordinatorEmail String?  @map("coordinator_email")
   createdAt        DateTime @default(now())
+  teams            Team[]
 
   @@map("events")
 }


### PR DESCRIPTION
This commit adds a new field, `leader`, to the User model and the Team model. The `leader` field in the User model establishes a one-to-one relationship with the Team model, indicating that a user can be the leader of a team. This change allows for better organization and management of teams within the application.